### PR TITLE
issue#60: optionally consider only active enrolments

### DIFF
--- a/assign.php
+++ b/assign.php
@@ -18,7 +18,7 @@
 require('../../config.php');
 require('graph_submission.php');
 require('javascriptfunctions.php');
-require('lib.php');
+require_once('lib.php');
 
 $course = required_param('id', PARAM_INT);
 

--- a/block_analytics_graphs.php
+++ b/block_analytics_graphs.php
@@ -85,4 +85,13 @@ class block_analytics_graphs extends block_base {
         $this->content->footer = '<hr/>';
         return $this->content;
     }
+
+    /**
+     * Enables global configuration of the block in settings.php.
+     *
+     * @return bool True if the global configuration is enabled.
+     */
+    public function has_config() {
+        return true;
+    }
 }  // Here's the closing bracket for the class definition.

--- a/block_analytics_graphs.php
+++ b/block_analytics_graphs.php
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/blocks/analytics_graphs/lib.php');
+
 class block_analytics_graphs extends block_base {
     public function init() {
         $this->title = get_string('analytics_graphs', 'block_analytics_graphs');
@@ -93,5 +97,32 @@ class block_analytics_graphs extends block_base {
      */
     public function has_config() {
         return true;
+    }
+
+    /**
+     * Enabled config per block.
+     *
+     * @return true
+     */
+    public function instance_allow_config() {
+        return (bool) get_config('block_analytics_graphs', 'overrideonlyactive');;
+    }
+
+    /**
+     * Process deletion of a block instance.
+     */
+    public function instance_delete() {
+        $needupdate = false;
+        $onlyactivecourses = block_analytics_graphs_get_onlyactivecourses();
+
+        // If related course has "onlyactive" setting enabled, we would like to clean it up on the block deletion.
+        if (($key = array_search($this->page->course->id, $onlyactivecourses)) !== false) {
+            unset($onlyactivecourses[$key]);
+            $needupdate = true;
+        }
+
+        if ($needupdate) {
+            set_config('onlyactivecourses', implode(',', $onlyactivecourses), 'block_analytics_graphs');
+        }
     }
 }  // Here's the closing bracket for the class definition.

--- a/edit_form.php
+++ b/edit_form.php
@@ -1,0 +1,89 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/blocks/analytics_graphs/lib.php');
+
+/**
+ * Form for editing lock instances.
+ *
+ * @package    block_analytics_graphs
+ * @copyright  2024 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class block_analytics_graphs_edit_form extends block_edit_form {
+
+    /**
+     * Block config form definition.
+     *
+     * @param \MoodleQuickForm $mform Block form.
+     *
+     * @return void
+     */
+    protected function specific_definition($mform) {
+        // Adding a new "only active" setting only of allowed for individual blocks.
+        if (get_config('block_analytics_graphs', 'overrideonlyactive')) {
+            $mform->addElement('header', 'configheader', get_string('blocksettings', 'block'));
+            $mform->addElement('advcheckbox', 'config_onlyactive', get_string('settings:onlyactive', 'block_analytics_graphs'));
+            $mform->addHelpButton('config_onlyactive', 'settings:onlyactive', 'block_analytics_graphs');
+            $mform->setDefault('config_onlyactive', (bool) get_config('block_analytics_graphs', 'onlyactive'));
+        }
+    }
+
+    /**
+     * Display the configuration form when block is being added to the page
+     *
+     * @return bool
+     */
+    public static function display_form_when_adding(): bool {
+        // Makes sense to display block's setting when adding a block only if allowed extra setting.
+        return (bool) get_config('block_analytics_graphs', 'overrideonlyactive');
+    }
+
+    /**
+     * Process the form submission, used if form was submitted via AJAX
+     */
+    public function process_dynamic_submission() {
+        parent::process_dynamic_submission();
+
+        // If allowed to have 'only active' setting per block,
+        // then we would like to update it based on the curren block data.
+        if (get_config('block_analytics_graphs', 'overrideonlyactive')) {
+            $needupdate = false;
+            $onlyactivecourses = block_analytics_graphs_get_onlyactivecourses();
+            $courseid = $this->page->course->id;
+            $data = $this->get_data();
+
+            if(!empty($data->config_onlyactive)) {
+                if (!in_array($courseid, $onlyactivecourses)) {
+                    $onlyactivecourses[] = $courseid;
+                    $needupdate = true;
+                }
+            } else {
+                if (($key = array_search($courseid, $onlyactivecourses)) !== false) {
+                    unset($onlyactivecourses[$key]);
+                    $needupdate = true;
+                }
+            }
+
+            // Conditionally save the settings only if updated.
+            if ($needupdate) {
+                set_config('onlyactivecourses', implode(',', $onlyactivecourses), 'block_analytics_graphs');
+            }
+        }
+    }
+}

--- a/email.php
+++ b/email.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 require_once("../../config.php");
-require('lib.php');
+require_once('lib.php');
 global $USER;
 global $DB;
 require_once($CFG->dirroot.'/lib/moodlelib.php');

--- a/graphresourcestartup.php
+++ b/graphresourcestartup.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 require('../../config.php');
-require('lib.php');
+require_once('lib.php');
 $course = required_param('id', PARAM_INT);
 global $DB;
 /* Access control */

--- a/graphresourceurl.php
+++ b/graphresourceurl.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 require('../../config.php');
-require('lib.php');
+require_once('lib.php');
 require('javascriptfunctions.php');
 $course = htmlspecialchars(required_param('id', PARAM_INT));
 $startdate = optional_param('from', '***', PARAM_TEXT);

--- a/hits.php
+++ b/hits.php
@@ -16,7 +16,7 @@
 
 
 require('../../config.php');
-require('lib.php');
+require_once('lib.php');
 require('javascriptfunctions.php');
 $course = required_param('id', PARAM_INT);
 $startdate = optional_param('from', '***', PARAM_TEXT);

--- a/hotpot.php
+++ b/hotpot.php
@@ -17,7 +17,7 @@
 require('../../config.php');
 require('graph_submission.php');
 require('javascriptfunctions.php');
-require('lib.php');
+require_once('lib.php');
 
 $course = required_param('id', PARAM_INT);
 

--- a/lang/en/block_analytics_graphs.php
+++ b/lang/en/block_analytics_graphs.php
@@ -199,3 +199,7 @@ $string['privacy:metadata:block_analytics_graphs_msg:subject'] = 'Subject of the
 $string['privacy:metadata:block_analytics_graphs_dest'] = 'Information about students that got messages.';
 $string['privacy:metadata:block_analytics_graphs_dest:toid'] = 'The ID of the user the message was sent to.';
 $string['privacy:metadata:block_analytics_graphs_dest:messageid'] = 'The ID of the message.';
+
+// Settings.
+$string['settings:onlyactive'] = 'Only active enrolments';
+$string['settings:onlyactivedescription'] = 'Consider only active enrolments for the reports';

--- a/lang/en/block_analytics_graphs.php
+++ b/lang/en/block_analytics_graphs.php
@@ -202,4 +202,6 @@ $string['privacy:metadata:block_analytics_graphs_dest:messageid'] = 'The ID of t
 
 // Settings.
 $string['settings:onlyactive'] = 'Only active enrolments';
-$string['settings:onlyactivedescription'] = 'Consider only active enrolments for the reports';
+$string['settings:onlyactive_help'] = 'Consider only active enrolments for the reports';
+$string['settings:overrideonlyactive'] = 'Allow \'Only active enrolments\' per block instance';
+$string['settings:overrideonlyactive_help'] = 'If enabled, then \'Only active enrolments\' can be set per block instance. Otherwise, global setting will be used for all blocks.';

--- a/lib.php
+++ b/lib.php
@@ -84,7 +84,7 @@ function block_analytics_graphs_get_students($course) {
     global $DB, $USER;
     $students = array();
     $context = context_course::instance($course->id);
-    $onlyactive = block_analytics_graphs_only_active_enrolments();
+    $onlyactive = block_analytics_graphs_only_active_enrolments($course);
     $allstudents = get_enrolled_users($context, 'block/analytics_graphs:bemonitored', 0,
         'u.id, u.firstname, u.lastname, u.email, u.suspended', 'firstname, lastname', 0, 0, $onlyactive);
     foreach ($allstudents as $student) {
@@ -101,7 +101,7 @@ function block_analytics_graphs_get_students($course) {
 function block_analytics_graphs_get_teachers($course) {
     $teachers = array();
     $context = context_course::instance($course);
-    $onlyactive = block_analytics_graphs_only_active_enrolments();
+    $onlyactive = block_analytics_graphs_only_active_enrolments($course);
     $allteachers = get_enrolled_users($context, 'block/analytics_graphs:viewpages', 0,
                     'u.id, u.firstname, u.lastname, u.email, u.suspended', 'firstname, lastname', 0, 0, $onlyactive);
     foreach ($allteachers as $teacher) {
@@ -764,10 +764,28 @@ function block_analytics_graphs_extend_navigation_course($navigation, $course, $
 }
 
 /**
- * Do we consider only active enrolments?
+ * Do we consider only active enrolments for a given course?
  *
+ * @param \stdClass $course Course instance.
  * @return bool
  */
-function block_analytics_graphs_only_active_enrolments() {
-    return (bool) get_config('block_analytics_graphs', 'onlyactive');
+function block_analytics_graphs_only_active_enrolments($course): bool {
+    // If only active setting is allowed per instance, let's try to see if it's enabled for a course we run a report on.
+    // Otherwise, use globally configured setting.
+    if (get_config('block_analytics_graphs', 'overrideonlyactive')) {
+        return in_array($course->id, block_analytics_graphs_get_onlyactivecourses());
+    } else {
+        return (bool) get_config('block_analytics_graphs', 'onlyactive');
+    }
+}
+
+/**
+ * Gets a list of courses with enabled "onlyactive" setting.
+ *
+ * @return array
+ */
+function block_analytics_graphs_get_onlyactivecourses(): array {
+    $onlyactivecourses = get_config('block_analytics_graphs', 'onlyactivecourses');
+
+    return !empty($onlyactivecourses) ? explode(',', $onlyactivecourses) : [];
 }

--- a/lib.php
+++ b/lib.php
@@ -84,9 +84,9 @@ function block_analytics_graphs_get_students($course) {
     global $DB, $USER;
     $students = array();
     $context = context_course::instance($course->id);
+    $onlyactive = block_analytics_graphs_only_active_enrolments();
     $allstudents = get_enrolled_users($context, 'block/analytics_graphs:bemonitored', 0,
-                    'u.id, u.firstname, u.lastname, u.email, u.suspended', 'firstname, lastname',
-                    0, 0, true); // Partial correction. The ideal is to allow selection.
+        'u.id, u.firstname, u.lastname, u.email, u.suspended', 'firstname, lastname', 0, 0, $onlyactive);
     foreach ($allstudents as $student) {
         if ($student->suspended == 0) {
             if (groups_user_groups_visible($course, $student->id)) {
@@ -101,8 +101,9 @@ function block_analytics_graphs_get_students($course) {
 function block_analytics_graphs_get_teachers($course) {
     $teachers = array();
     $context = context_course::instance($course);
+    $onlyactive = block_analytics_graphs_only_active_enrolments();
     $allteachers = get_enrolled_users($context, 'block/analytics_graphs:viewpages', 0,
-                    'u.id, u.firstname, u.lastname, u.email, u.suspended', 'firstname, lastname');
+                    'u.id, u.firstname, u.lastname, u.email, u.suspended', 'firstname, lastname', 0, 0, $onlyactive);
     foreach ($allteachers as $teacher) {
         if ($teacher->suspended == 0) {
             $teachers[] = $teacher;
@@ -760,4 +761,13 @@ function block_analytics_graphs_extend_navigation_course($navigation, $course, $
                 $url, navigation_node::TYPE_SETTING, null, null, new pix_icon('i/report', ''));
         $reportanalyticsgraphs->add_node($node);
     }
+}
+
+/**
+ * Do we consider only active enrolments?
+ *
+ * @return bool
+ */
+function block_analytics_graphs_only_active_enrolments() {
+    return (bool) get_config('block_analytics_graphs', 'onlyactive');
 }

--- a/query_grades.php
+++ b/query_grades.php
@@ -19,6 +19,7 @@
 require_once("../../config.php");
 global $DB;
 require_once($CFG->dirroot.'/lib/moodlelib.php');
+require('lib.php');
 
 $courseid = required_param('course_id', PARAM_INT);
 $formdata = required_param_array('form_data', PARAM_INT);
@@ -36,9 +37,10 @@ $sql = "SELECT itemid + (userid*1000000) AS id, itemid, userid, usr.firstname,
             ORDER BY id";
 
 $result = $DB->get_records_sql($sql, $inparams);
+$students = array_column(block_analytics_graphs_get_students($COURSE), 'id');
 $taskgrades = new stdClass();
 foreach ($result as $id => $taskattrs) {
-    if (groups_user_groups_visible($COURSE, $taskattrs->userid)) {
+    if (in_array($taskattrs->userid, $students) && groups_user_groups_visible($COURSE, $taskattrs->userid)) {
         $itemid = $taskattrs->itemid;
         $record = new stdClass();
         $record->userid = $taskattrs->userid;

--- a/query_grades.php
+++ b/query_grades.php
@@ -19,7 +19,7 @@
 require_once("../../config.php");
 global $DB;
 require_once($CFG->dirroot.'/lib/moodlelib.php');
-require('lib.php');
+require_once('lib.php');
 
 $courseid = required_param('course_id', PARAM_INT);
 $formdata = required_param_array('form_data', PARAM_INT);

--- a/quiz.php
+++ b/quiz.php
@@ -17,7 +17,7 @@
 require('../../config.php');
 require('graph_submission.php');
 require('javascriptfunctions.php');
-require('lib.php');
+require_once('lib.php');
 
 $course = required_param('id', PARAM_INT);
 

--- a/settings.php
+++ b/settings.php
@@ -28,7 +28,14 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configcheckbox(
         'block_analytics_graphs/onlyactive',
         get_string('settings:onlyactive', 'block_analytics_graphs'),
-        get_string('settings:onlyactivedescription', 'block_analytics_graphs'),
+        get_string('settings:onlyactive_help', 'block_analytics_graphs'),
+        0)
+    );
+
+    $settings->add(new admin_setting_configcheckbox(
+        'block_analytics_graphs/overrideonlyactive',
+        get_string('settings:overrideonlyactive', 'block_analytics_graphs'),
+        get_string('settings:overrideonlyactive_help', 'block_analytics_graphs'),
         0)
     );
 }

--- a/settings.php
+++ b/settings.php
@@ -14,11 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Settings for the HTML block
+ *
+ * @package   block_analytics_graphs
+ * @copyright 2023 Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
-defined('MOODLE_INTERNAL') || die();
-$plugin->version = 2024100205;  // YYYYMMDDHH (year, month, day, 24-hr time).
-$plugin->requires = 2015111600; // YYYYMMDDHH (This is the release version for Moodle 3.0).
-$plugin->maturity = MATURITY_STABLE;
-$plugin->release = '4.2.2';
-$plugin->branch = '4.2';
-$plugin->component = 'block_analytics_graphs';
+defined('MOODLE_INTERNAL') || die;
+
+if ($ADMIN->fulltree) {
+    $settings->add(new admin_setting_configcheckbox(
+        'block_analytics_graphs/onlyactive',
+        get_string('settings:onlyactive', 'block_analytics_graphs'),
+        get_string('settings:onlyactivedescription', 'block_analytics_graphs'),
+        0)
+    );
+}

--- a/timeaccesseschart.php
+++ b/timeaccesseschart.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 require('../../config.php');
-require('lib.php');
+require_once('lib.php');
 require('javascriptfunctions.php');
 $course = required_param('id', PARAM_INT);
 $days = required_param('days', PARAM_INT);

--- a/turnitin.php
+++ b/turnitin.php
@@ -17,7 +17,7 @@
 require('../../config.php');
 require('graph_submission.php');
 require('javascriptfunctions.php');
-require('lib.php');
+require_once('lib.php');
 
 $course = required_param('id', PARAM_INT);
 

--- a/version.php
+++ b/version.php
@@ -16,7 +16,7 @@
 
 
 defined('MOODLE_INTERNAL') || die();
-$plugin->version = 2024100205;  // YYYYMMDDHH (year, month, day, 24-hr time).
+$plugin->version = 2024100206;  // YYYYMMDDHH (year, month, day, 24-hr time).
 $plugin->requires = 2015111600; // YYYYMMDDHH (This is the release version for Moodle 3.0).
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '4.2.2';


### PR DESCRIPTION
This patch fixes issue #60 and adds an additional setting to exclude inactive enrolments from the reports. Optionally you can enable "Only active enrolments" per  block instance.

Testing:
1. Disable "Only active enrolments" and "Allow 'Only active enrolments' per block instance" and **confirm** that you don't see any block settings while adding a block to a course. Also **confirm** that suspended users are displayed in reports data. 
2. Enable "Only active enrolments" and **confirm** that you don't see any block settings while adding a block to a course. Also **confirm** that suspended users are **not** displayed in reports data.
3. Enable "Only active enrolments" and "Allow 'Only active enrolments' per block instance" and **confirm** that you  see "Only active enrolments" block setting while adding a block to a course. **Confirm** that "Only active enrolments" is ticked by default when adding a block. Also **confirm** that suspended users are displayed or not based on the setting per block.   
4. Play with "Only active enrolments" (enabled/disable) for you block and **confirm** that you see user data based on the setting.
5. Disable global "Only active enrolments", but leave "Allow 'Only active enrolments' per block instance" enabled. **confirm** that you  see "Only active enrolments" block setting while adding a block to a course. **Confirm** that "Only active enrolments" is **not** ticked by default when adding a block. 
6. While you have global settings from step 5,  enable  "Only active enrolments" for your block and save. Then delete the block. Add a block again and **confirm** that "Only active enrolments" is **not** ticked by default when adding a block. 

Two new settings 
![image](https://github.com/user-attachments/assets/64a8437c-658a-4e8e-9512-07bfc62aa5d8)

Block setting when adding a block
![image](https://github.com/user-attachments/assets/6debb8c5-91db-4cca-98fe-e303e13d2c33)
